### PR TITLE
Approve server ADR (Apache)

### DIFF
--- a/adr/002-server.md
+++ b/adr/002-server.md
@@ -1,8 +1,8 @@
 # Web server
 
-* Status: proposed
+* Status: **approved**
 * Deciders: [Shawn Allen](https://github.com/shawnbot)
-* Date: 2022-03-21
+* Date: 2022-03-23
 
 ## Context and Problem Statement
 
@@ -34,15 +34,18 @@ All of the considered options have a proven track record of working in this conf
 
 ## Decision outcome
 
-Chosen option: **TBD**
+Chosen option: **[Apache](#apache)**
 
-### Positive Consequences <!-- optional -->
+### Positive consequences <!-- optional -->
 
-* TBD
+* It does everything we need it to
+* Apache is the most mature option, so tutorials and examples are widespread
+* Its documentation is great
 
-### Negative Consequences <!-- optional -->
+### Negative consequences <!-- optional -->
 
-* TBD
+* We don't get to brag about using a more "modern" server
+* No built-in HTTP "normalization" or protection from malicious/malformed requests (but examples for said protection are easy to find!)
 
 ## Pros and cons of each option
 


### PR DESCRIPTION
I'm self-approving the server software ADR and going with Apache. I think it's pretty clear why from the ADR itself, and I've included my notes from #8 after creating sample configs for Apache, HAProxy, and NGINX below.

> Some notes from this exercise of mocking up [sample configurations](https://gist.github.com/shawnbot/16e2437f73b7fdcf9f2cc85f0abd2f9d):
>
> - The Apache config ([httpd.conf](https://gist.github.com/shawnbot/16e2437f73b7fdcf9f2cc85f0abd2f9d#file-httpd-conf)) is by far the easiest for me to understand. The [HAProxy config](https://gist.github.com/shawnbot/16e2437f73b7fdcf9f2cc85f0abd2f9d#file-haproxy-cfg) is _really_ odd, IMO.
> - Apache and HAProxy both interpolate environment variables on their own. The NGINX config needs to be preprocessed, e.g. [with `envsubst`](https://github.com/docker-library/docs/tree/master/nginx#using-environment-variables-in-nginx-configuration).
> - Apache's `RewriteMap` directive makes slightly more sense to me than NGINX's `map/if/return` sequence, which itself makes a _lot_ more sense to me than the [suggested method](https://stackoverflow.com/a/23157484) for redirect maps in HAProxy 🙃 
> - HAProxy doesn't serve static content on its own (it's only a proxy), so if we go that route we'd need to have a separate app server for `archive.sf.gov` assets