### PR TITLE
Add support for URL resolution at /_/<url>

### DIFF
--- a/features/server.feature
+++ b/features/server.feature
@@ -1,0 +1,28 @@
+Feature: Server
+  Scenario: Static files
+    Given request header Host: ${TEST_SUBDOMAIN}archive.sf.gov
+    When I visit /js/snapshot.js
+    Then I should get status code 200
+    And I should get header "Content-type" containing "application/javascript"
+
+  Scenario: Explicit site redirect
+    Given request header Host: ${TEST_SUBDOMAIN}sftreasureisland.org
+    When I visit /
+    Then I should be redirected to https://sf.gov/departments/city-administrator/treasure-island-development-authority
+
+  Scenario: Site archive (internal 404)
+    Given request header Host: ${TEST_SUBDOMAIN}sftreasureisland.org
+    When I visit /blah
+    Then I should be redirected to https://wayback.archive-it.org/18901/3/https://sftreasureisland.org/blah
+    When I follow the redirect
+    Then I should get header "Content-type" containing "text/html"
+    And I should get status code 404
+
+  Scenario: /_/ URL aliases
+    Given request header Host: ${TEST_SUBDOMAIN}archive.sf.gov
+    When I visit /_/sftreasureisland.org
+    Then I should be redirected to https://sf.gov/departments/city-administrator/treasure-island-development-authority
+    When I visit /_/sftreasureisland.org/
+    Then I should be redirected to https://sf.gov/departments/city-administrator/treasure-island-development-authority
+    When I visit /_/sftreasureisland.org/blah
+    Then I should be redirected to https://wayback.archive-it.org/18901/3/https://sftreasureisland.org/blah

--- a/src/app.js
+++ b/src/app.js
@@ -47,7 +47,7 @@ module.exports = async function createApp (options) {
  * routers to determine the _intended_ `hostname`, `path`, and originalUrl (path +
  * query string)
  *
- * @param {{ prefix: string, log: import('signales').SignaleType }} options
+ * @param {{ prefix: string, log: import('signales').SignaleEntrypoint }} options
  * @returns {express.RequestHandler}
  */
 function urlAliasHandler ({ prefix, log }) {

--- a/src/sites.js
+++ b/src/sites.js
@@ -154,8 +154,9 @@ class Site {
       handlers.push(staticRouter)
     }
     handlers.push(this.createRequestHandler())
-    return router.use(path, (req, res, next) => {
-      if (this.matchesHost(req.hostname)) {
+    return router.use(path, /** @type {express.RequestHandler} */ (req, res, next) => {
+      const hostname = res.locals.hostname || req.hostname
+      if (this.matchesHost(hostname)) {
         next()
       } else {
         next('router')
@@ -245,13 +246,15 @@ class Site {
    */
   createRequestHandler (options) {
     return (req, res, next) => {
-      this.log.info(req.path, req.originalUrl)
-      const redirect = this.resolve([req.originalUrl, req.path])
+      const path = res.locals.path || req.path
+      const originalUrl = res.locals.originalUrl || req.originalUrl
+      this.log.info(path, originalUrl)
+      const redirect = this.resolve([originalUrl, path])
       if (redirect) {
         this.log.success('redirect:', redirect)
         return res.redirect(REDIRECT_PERMANENT, redirect)
       } else {
-        const archiveUrl = this.getArchiveUrl(req.originalUrl)
+        const archiveUrl = this.getArchiveUrl(originalUrl)
         this.log.success('archive:', archiveUrl)
         return res.redirect(REDIRECT_PERMANENT, archiveUrl)
       }


### PR DESCRIPTION
**Problem**: there's no simple way for people without CLI chops (or other HTTP tools) to set the `Host` header when making requests.

**Solution**: The `/_/<url>` endpoint parses the `<url>` portion of the path and sets response variables that our site configurations can use to determine the _simulated_ hostname, path, and query string of the request and apply the same routing logic. This makes it possible to test routing logic from this PR's review app with URLs like:

- https://sfgov-archive-pr-21.herokuapp.com/_/sftreasureisland.org (`curl -H 'Host: sftreasureisland.org' http://sfgov-archive-pr-21.herokuapp.com`)
- https://sfgov-archive-pr-21.herokuapp.com/_/www.sftreasureisland.org/treasure-island-museum (`curl -H 'Host: sftreasureisland.org' http://sfgov-archive-pr-21.herokuapp.com/treasure-island-museum`)
- https://sfgov-archive-pr-21.herokuapp.com/_/innovation.sfgov.org (`curl -H 'Host: innovation.sfgov.org' http://sfgov-archive-pr-21.herokuapp.com`)
- https://sfgov-archive-pr-21.herokuapp.com/_/innovation.sfgov.org/resources (`curl -H 'Host: innovation.sfgov.org' http://sfgov-archive-pr-21.herokuapp.com/resources`)

**Bonus**: it works over HTTPS 😁 