### PR TITLE
Add trailing-slash redirect option, shore up test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,3 +19,8 @@ jobs:
         run: npm run lint
       - name: unit tests
         run: npm run test:unit
+      - name: Coveralls
+        uses: coverallsapp/github-action@1.1.3
+        with:
+          github-token: ${{ github.token }}
+          flag-name: unit

--- a/__tests__/__fixtures__/basic-site.yml
+++ b/__tests__/__fixtures__/basic-site.yml
@@ -1,5 +1,4 @@
-archive:
-  base_url: https://sfgov.org/old-url
+base_url: https://sfgov.org/old-url
 
 hostnames:
   - www.sfgov.org

--- a/__tests__/data.js
+++ b/__tests__/data.js
@@ -1,0 +1,71 @@
+const { YAMLException } = require('js-yaml')
+const { loadRedirects, readYAML } = require('../src/data')
+
+describe.skip('getHostnames()', () => {
+  // TODO
+})
+
+describe.skip('getInlineRedirects()', () => {
+  // TODO
+})
+
+describe('readYAML()', () => {
+  it('works', () => {
+    expect(readYAML('__tests__/__fixtures__/basic-site.yml')).resolves.toMatchObject({
+      base_url: 'https://sfgov.org/old-url'
+    })
+  })
+
+  it('throws YAML parse errors', () => {
+    expect(readYAML('__tests__/__fixtures__/invalid-site.yml')).rejects.toThrow(YAMLException)
+  })
+
+  it('throws if the path does not exist', () => {
+    expect(readYAML('nope/nope/nopity/nope.yml')).rejects.toThrow(/ENOENT/)
+  })
+})
+
+describe('loadRedirects()', () => {
+  const targetPath = '/home'
+  const expectedUrl = 'https://example.com/'
+
+  it('throws on falsy sources', async () => {
+    expect(loadRedirects(null)).rejects.toThrow(/Expected array/)
+    expect(loadRedirects({})).rejects.toThrow(/Expected array/)
+  })
+
+  it('defaults relativePath to "."', async () => {
+    const redirects = await loadRedirects([{
+      file: '__tests__/__fixtures__/basic-redirects.tsv'
+    }])
+    expect(redirects).toBeInstanceOf(Map)
+    expect(redirects.get(targetPath)).toEqual(expectedUrl)
+  })
+
+  it('does not use the relativePath if falsy', async () => {
+    const redirects = await loadRedirects([{
+      file: '__tests__/__fixtures__/basic-redirects.tsv'
+    }], null)
+    expect(redirects).toBeInstanceOf(Map)
+    expect(redirects.get(targetPath)).toEqual(expectedUrl)
+  })
+
+  it('respects the relative path', async () => {
+    const redirects = await loadRedirects([{
+      file: '__fixtures__/basic-redirects.tsv'
+    }], '__tests__')
+    expect(redirects).toBeInstanceOf(Map)
+    expect(redirects.get(targetPath)).toEqual(expectedUrl)
+  })
+
+  describe('trailing-slash option', () => {
+    it('adds slashes', async () => {
+      const redirects = await loadRedirects([{
+        file: '__tests__/__fixtures__/basic-redirects.tsv',
+        'trailing-slash': true
+      }])
+      expect(redirects.get(targetPath)).toEqual(expectedUrl)
+      expect(redirects.get(`${targetPath}/`)).toEqual(expectedUrl)
+    })
+  })
+})

--- a/__tests__/server.js
+++ b/__tests__/server.js
@@ -2,7 +2,6 @@
 const express = require('express')
 const supertest = require('supertest')
 const createApp = require('../src/app')
-const { REDIRECT_TEMPORARY, REDIRECT_PERMANENT } = require('../src/constants')
 const { Site } = require('../src/sites')
 
 require('../lib/test-setup')

--- a/__tests__/server.js
+++ b/__tests__/server.js
@@ -1,6 +1,11 @@
+
 const express = require('express')
 const supertest = require('supertest')
 const createApp = require('../src/app')
+const { REDIRECT_TEMPORARY, REDIRECT_PERMANENT } = require('../src/constants')
+const { Site } = require('../src/sites')
+
+require('../lib/test-setup')
 
 const allowedMethods = ['GET', 'HEAD', 'OPTIONS']
 const notAllowedMethods = [
@@ -25,6 +30,73 @@ describe('createApp()', () => {
   })
 })
 
+describe('url aliasing at /_/', () => {
+  let server
+  beforeAll(async () => {
+    server = await createServer({
+      sites: [
+        new Site({
+          name: 'a',
+          base_url: 'https://a.com',
+          hostnames: ['www.a.com'],
+          archive: {
+            collection_id: 123
+          },
+          redirects: [
+            {
+              map: {
+                '/': 'https://example.com/a'
+              }
+            }
+          ]
+        }),
+        new Site({
+          name: 'b',
+          base_url: 'https://b.com',
+          hostnames: ['www.b.com'],
+          redirects: [
+            {
+              map: {
+                '/': 'https://example.com/b'
+              }
+            }
+          ]
+        })
+      ]
+    })
+  })
+
+  it('routes url alias redirects', async () => {
+    await expect(supertest(server).get('/_/a.com'))
+      .resolves.toBeSupertestRedirect('https://example.com/a')
+    await expect(supertest(server).get('/_/www.a.com'))
+      .resolves.toBeSupertestRedirect('https://example.com/a')
+    await expect(supertest(server).get('/_/b.com'))
+      .resolves.toBeSupertestRedirect('https://example.com/b')
+    await expect(supertest(server).get('/_/www.b.com'))
+      .resolves.toBeSupertestRedirect('https://example.com/b')
+  })
+
+  it('404s on unhandled domains', async () => {
+    await expect(supertest(server).get('/_/c.com'))
+      .resolves.toMatchObject({ statusCode: 404 })
+  })
+
+  it('40Xs on bad URLs', async () => {
+    await expect(supertest(server).get('/_/://'))
+      .resolves.toMatchObject({ statusCode: 404 })
+    await expect(supertest(server).get('/_/:://'))
+      .resolves.toMatchObject({ statusCode: 404 })
+    await expect(supertest(server).get('/_//::'))
+      .resolves.toMatchObject({ statusCode: 404 })
+  })
+
+  it('ignores the query string', async () => {
+    await expect(supertest(server).get('/_/a.com?foo=bar'))
+      .resolves.toBeSupertestRedirect('https://example.com/a')
+  })
+})
+
 describe('server logic', () => {
   describe.skip('allowed methods', () => {
     it('allows read-only HTTP verbs', async () => {
@@ -44,7 +116,10 @@ describe('server logic', () => {
 })
 
 async function createServer (options) {
-  const app = await createApp(options)
+  const app = await createApp({
+    logger: false,
+    ...options
+  })
   return express().use(app)
 }
 

--- a/__tests__/sites.js
+++ b/__tests__/sites.js
@@ -1,6 +1,5 @@
 /* eslint-disable promise/always-return */
 const { Site } = require('../src/sites')
-const { loadRedirects } = require('../src/data')
 const { readFileSync } = require('node:fs')
 const express = require('express')
 const supertest = require('supertest')
@@ -13,21 +12,14 @@ const EXAMPLE_BASE_URL_SLASH = `${EXAMPLE_BASE_URL}/`
 describe('Site', () => {
   describe('name', () => {
     it('names sites appropriately', () => {
-      expect(new Site({
-        base_url: EXAMPLE_BASE_URL,
-        name: 'foo'
-      }).name).toBe('"foo"')
-      expect(new Site({
-        base_url: EXAMPLE_BASE_URL
-      }).name).toBe('<example.com>')
+      expect(new Site({ base_url: EXAMPLE_BASE_URL, name: 'foo' }).name).toBe('"foo"')
+      expect(new Site({ base_url: EXAMPLE_BASE_URL }).name).toBe('<example.com>')
     })
   })
 
   describe('base URL', () => {
     it('works with base_url', () => {
-      const site = new Site({
-        base_url: EXAMPLE_BASE_URL
-      })
+      const site = new Site({ base_url: EXAMPLE_BASE_URL })
       expect(String(site.baseUrl)).toBe(EXAMPLE_BASE_URL_SLASH)
     })
     it('works with archive.base_url', () => {
@@ -365,36 +357,5 @@ describe('Site', () => {
     it('throws if the file does not parse', async () => {
       expect(Site.loadAll('__tests__/__fixtures__/invalid-*.yml')).rejects.toBeInstanceOf(YAMLException)
     })
-  })
-})
-
-describe('loadRedirects()', () => {
-  it('throws on falsy sources', async () => {
-    expect(loadRedirects(null)).rejects.toThrow(/Expected array/)
-    expect(loadRedirects({})).rejects.toThrow(/Expected array/)
-  })
-
-  it('defaults relativePath to "."', async () => {
-    const redirects = await loadRedirects([{
-      file: '__tests__/__fixtures__/basic-redirects.tsv'
-    }])
-    expect(redirects).toBeInstanceOf(Map)
-    expect(redirects.get('/home')).toEqual('https://example.com/')
-  })
-
-  it('does not use the relativePath if falsy', async () => {
-    const redirects = await loadRedirects([{
-      file: '__tests__/__fixtures__/basic-redirects.tsv'
-    }], null)
-    expect(redirects).toBeInstanceOf(Map)
-    expect(redirects.get('/home')).toEqual('https://example.com/')
-  })
-
-  it('respects the relative path', async () => {
-    const redirects = await loadRedirects([{
-      file: '__fixtures__/basic-redirects.tsv'
-    }], '__tests__')
-    expect(redirects).toBeInstanceOf(Map)
-    expect(redirects.get('/home')).toEqual('https://example.com/')
   })
 })

--- a/__tests__/sites.js
+++ b/__tests__/sites.js
@@ -22,6 +22,7 @@ describe('Site', () => {
       }).name).toBe('<example.com>')
     })
   })
+
   describe('base URL', () => {
     it('works with base_url', () => {
       const site = new Site({

--- a/__tests__/sites.js
+++ b/__tests__/sites.js
@@ -1,5 +1,6 @@
 /* eslint-disable promise/always-return */
-const { Site, loadRedirects } = require('../src/sites')
+const { Site } = require('../src/sites')
+const { loadRedirects } = require('../src/data')
 const { readFileSync } = require('node:fs')
 const express = require('express')
 const supertest = require('supertest')

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -1,9 +1,9 @@
-/* eslint-disable no-template-curly-in-string */
 const { expandEnvVars, getFullUrl, unique } = require('../src/utils')
 
 describe('expandEnvVars()', () => {
   const testKey = `TEST_${Date.now().toString(32)}`
   const testValue = 'Hello!'
+  /* eslint-disable no-template-curly-in-string */
   const testStrings = [
     [`$${testKey}`, testValue],
     [`\${${testKey}}`, testValue],

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-template-curly-in-string */
-const { expandEnvVars, unique } = require('../src/utils')
+const { expandEnvVars, getFullUrl, unique } = require('../src/utils')
 
 describe('expandEnvVars()', () => {
   const testKey = `TEST_${Date.now().toString(32)}`
@@ -43,6 +43,18 @@ describe('expandEnvVars()', () => {
         expect(expandEnvVars(str, { FOO: value })).toBe('foo: ')
       }
     }
+  })
+})
+
+describe('getFullUrl()', () => {
+  it('passes through protocol-qualified URLs', () => {
+    expect(getFullUrl('http://foo.com')).toBeURL('http://foo.com/')
+    expect(getFullUrl('http://foo.com/bar')).toBeURL('http://foo.com/bar')
+  })
+
+  it('respects protocol-relative URLs', () => {
+    expect(getFullUrl('//example.com')).toBeURL('https://example.com/')
+    expect(getFullUrl('//example.com', 'http')).toBeURL('http://example.com/')
   })
 })
 

--- a/config/schemas/site.json
+++ b/config/schemas/site.json
@@ -52,6 +52,10 @@
                 "additionalProperties": {
                   "type": "string"
                 }
+              },
+              "trailing-slash": {
+                "description": "If true, also add redirects for paths with a trailing slash",
+                "type": "boolean"
               }
             }
           },
@@ -67,6 +71,10 @@
                 "oneOf": [
                   { "const": "tsv" }
                 ]
+              },
+              "trailing-slash": {
+                "description": "If true, also add redirects for paths with a trailing slash",
+                "type": "boolean"
               }
             }
           }

--- a/config/sites/default.yml
+++ b/config/sites/default.yml
@@ -9,5 +9,5 @@ static:
 
 hostnames:
   - localhost
-  - '*.archive.sf.gov'
+  - '${HEROKU_APP_NAME}.archive.sf.gov'
   - '${HEROKU_APP_NAME}.herokuapp.com'

--- a/config/sites/innovation.sfgov/innovation.sfgov.yml
+++ b/config/sites/innovation.sfgov/innovation.sfgov.yml
@@ -25,3 +25,4 @@ redirects:
       /projectsummaries: https://sf.gov/case-studies
       /resources: https://sf.gov/departments/mayors-office-innovation#resources
       /what-we-do-1: https://sf.gov/civic-bridge
+    trailing-slash: true

--- a/features/server.feature
+++ b/features/server.feature
@@ -26,3 +26,7 @@ Feature: Server
     Then I should be redirected to https://sf.gov/departments/city-administrator/treasure-island-development-authority
     When I visit /_/sftreasureisland.org/blah
     Then I should be redirected to https://wayback.archive-it.org/18901/3/https://sftreasureisland.org/blah
+    When I visit /_/innovation.sfgov.org/resources
+    Then I should be redirected to https://sf.gov/departments/mayors-office-innovation#resources
+    When I visit /_/innovation.sfgov.org/resources/
+    Then I should be redirected to https://sf.gov/departments/mayors-office-innovation#resources

--- a/features/setup.js
+++ b/features/setup.js
@@ -5,9 +5,9 @@ const { URL } = require('node:url')
 const { expandEnvVars, getFullUrl } = require('../src/utils')
 const { REDIRECT_PERMANENT, REDIRECT_TEMPORARY } = require('../src/constants')
 
-require('dotenv').config()
+require('../lib/test-setup')
 
-const anyRedirectStatus = [REDIRECT_PERMANENT, REDIRECT_TEMPORARY]
+require('dotenv').config()
 
 const {
   TEST_BASE_URL,
@@ -51,7 +51,7 @@ When('I visit {url}', async function (url) {
 })
 
 Then('I should be redirected to {url}', function (url) {
-  expect(this.response).toRedirectTo(expandEnvVars(url))
+  expect(this.response).toBeFetchRedirect(expandEnvVars(url))
 })
 
 Then('I follow the redirect', async function () {
@@ -60,11 +60,11 @@ Then('I follow the redirect', async function () {
 })
 
 Then('I should be redirected permanently to {url}', function (url) {
-  expect(this.response).toRedirectTo(expandEnvVars(url), REDIRECT_PERMANENT)
+  expect(this.response).toBeFetchRedirect(expandEnvVars(url), REDIRECT_PERMANENT)
 })
 
 Then('I should be redirected temporarily to {url}', function (url) {
-  expect(this.response).toRedirectTo(expandEnvVars(url), REDIRECT_TEMPORARY)
+  expect(this.response).toBeFetchRedirect(expandEnvVars(url), REDIRECT_TEMPORARY)
 })
 
 Then('I should get status code {int}', function (code) {
@@ -145,32 +145,6 @@ function getEnvTestUrl () {
   }
   return `http://localhost:${PORT}`
 }
-
-expect.extend({
-  /**
-   *
-   * @param {fetch.Response} res
-   * @param {string} url
-   * @param {number} expectedStatus
-   * @returns {{ pass: boolean, message: () => string }}
-   */
-  toRedirectTo (res, url, expectedStatus) {
-    const { status, headers } = res
-    const matchesStatus = expectedStatus
-      ? status === expectedStatus
-      : anyRedirectStatus.includes(status)
-    const locationHeader = headers.get('Location')
-    const locationMatch = locationHeader === url
-    return {
-      pass: matchesStatus && locationMatch,
-      message () {
-        return matchesStatus
-          ? `Expected Location header to match:\n\t${url}\nbut got:\n\t${locationHeader}`
-          : `Expected HTTP status ${expectedStatus || anyRedirectStatus.join(' or ')}, but got ${status}`
-      }
-    }
-  }
-})
 
 function debug (...args) {
   if (NODE_ENV === 'development' || DEBUG === '1') {

--- a/features/setup.js
+++ b/features/setup.js
@@ -2,7 +2,7 @@ const { setWorldConstructor, defineParameterType, Given, When, Then } = require(
 const fetch = require('node-fetch')
 const expect = require('expect')
 const { URL } = require('node:url')
-const { expandEnvVars } = require('../src/utils')
+const { expandEnvVars, getFullUrl } = require('../src/utils')
 const { REDIRECT_PERMANENT, REDIRECT_TEMPORARY } = require('../src/constants')
 
 require('dotenv').config()
@@ -105,15 +105,9 @@ setWorldConstructor(class RequestWorld {
   }
 
   getFullUrl (str, defaultProtocol = 'http') {
-    if (str.includes('://')) {
-      return new URL(str)
-    } else if (str.startsWith('//')) {
-      return new URL(`${defaultProtocol}:${str}`)
-    } else if (str.startsWith('/')) {
-      return new URL(str, this.baseUrl)
-    } else {
-      return new URL(`${defaultProtocol}://${str}`)
-    }
+    return str.startsWith('/')
+      ? new URL(str, this.baseUrl)
+      : getFullUrl(str, defaultProtocol)
   }
 
   async load (url, options = {}) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,11 +9,15 @@ export type ArchiveMetadata = {
 
 export type RedirectMap = Map<string, string>
 
-export type RedirectMapEntry = {
+type BaseRedirectEntry = {
+  'trailing-slash': boolean
+}
+
+export type RedirectMapEntry = BaseRedirectEntry & {
   map: Record<string, string>
 }
 
-export type RedirectFileEntry = {
+export type RedirectFileEntry = BaseRedirectEntry & {
   file: string
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import express from 'express'
+import type express from 'express'
 import type { ServeStaticOptions } from '@types/serve-static'
 
 export type ArchiveMetadata = {
@@ -36,6 +36,7 @@ export type SiteConfigData = {
 export type AppOptions = {
   sites: ISite[]
   allowedMethods: string[]
+  logger?: express.RequestHandler
 }
 
 export interface ISite {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,11 @@
 /** @type {import('jest').Config} */
 module.exports = {
   collectCoverage: true,
+  coverageThreshold: {
+    global: {
+      lines: 100
+    }
+  },
   setupFiles: [
     './lib/test-setup.js'
   ]

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,7 @@
 /** @type {import('jest').Config} */
 module.exports = {
-  collectCoverage: true
+  collectCoverage: true,
+  setupFiles: [
+    './lib/test-setup.js'
+  ]
 }

--- a/lib/test-setup.js
+++ b/lib/test-setup.js
@@ -1,0 +1,49 @@
+const expect = require('expect')
+const { REDIRECT_PERMANENT } = require('../src/constants')
+
+expect.extend({
+  /**
+   *
+   * @param {import('node-fetch').Response} res
+   * @param {string} url
+   * @param {number?} expectedStatus
+   */
+  toBeFetchRedirect (res, url, expectedStatus = REDIRECT_PERMANENT) {
+    return matchRedirect({
+      status: res.statusCode,
+      location: res.headers.get('location')
+    }, url, expectedStatus)
+  },
+
+  /**
+   *
+   * @param {import('supertest').Response} res
+   * @param {string} url
+   * @param {number?} expectedStatus
+   */
+  toBeSupertestRedirect (res, url, expectedStatus = REDIRECT_PERMANENT) {
+    return matchRedirect({
+      status: res.statusCode,
+      location: res.headers.location
+    }, url, expectedStatus)
+  }
+})
+
+/**
+ * @param {{ status: number, location: string }} res
+ * @param {string} expectedLocation
+ * @param {number} expectedStatus
+ * @returns {{ pass: boolean, message: () => string }}
+ */
+function matchRedirect ({ status, location }, expectedLocation, expectedStatus = REDIRECT_PERMANENT) {
+  const matchesStatus = status === expectedStatus
+  const matchesLocation = location === expectedLocation
+  return {
+    pass: matchesStatus && matchesLocation,
+    message: () => {
+      return matchesStatus
+        ? `Expected location "${expectedLocation}", but got "${location}"`
+        : `Expected ${expectedStatus}, but got ${status}`
+    }
+  }
+}

--- a/lib/test-setup.js
+++ b/lib/test-setup.js
@@ -4,6 +4,36 @@ const { REDIRECT_PERMANENT } = require('../src/constants')
 expect.extend({
   /**
    *
+   * @param {URL} instance
+   * @param {string | Record<string,string>} stringOrProps
+   */
+  toBeURL (instance, stringOrProps) {
+    if (!(instance instanceof URL)) {
+      return {
+        pass: false,
+        message: `Expected URL instance but got ${typeof URL}`
+      }
+    }
+
+    if (typeof stringOrProps === 'string') {
+      return {
+        pass: instance.toString() === stringOrProps,
+        message: () => `Expected URL "${stringOrProps}", but got "${instance}"`
+      }
+    } else {
+      const mismatches = Object.entries(stringOrProps)
+        .filter(([key, value]) => instance[key] !== value)
+      return {
+        pass: mismatches.length === 0,
+        message: () => mismatches
+          .map(([key, value]) => `Expected url.${key} === ${JSON.stringify(value)}, but got ${JSON.stringify(instance[key])})`)
+          .join('\n')
+      }
+    }
+  },
+
+  /**
+   *
    * @param {import('node-fetch').Response} res
    * @param {string} url
    * @param {number?} expectedStatus

--- a/lib/test-setup.js
+++ b/lib/test-setup.js
@@ -40,7 +40,7 @@ expect.extend({
    */
   toBeFetchRedirect (res, url, expectedStatus = REDIRECT_PERMANENT) {
     return matchRedirect({
-      status: res.statusCode,
+      status: res.status,
       location: res.headers.get('location')
     }, url, expectedStatus)
   },

--- a/src/app.js
+++ b/src/app.js
@@ -15,8 +15,11 @@ module.exports = async function createApp (options) {
   const log = require('./log').scope('app')
 
   const {
-    sites = []
+    sites = [],
+    logger
   } = options || {}
+
+  const aliasPrefix = '/_/'
 
   const app = express()
     // disable the X-Powered-By: Express header
@@ -24,9 +27,9 @@ module.exports = async function createApp (options) {
     // only trust one level of proxy forwarding
     // see: <https://expressjs.com/en/guide/behind-proxies.html>
     .set('trust proxy', 1)
-    .use(morgan('combined'))
-    .use('/_/', urlAliasHandler({
-      prefix: '/_/',
+    .use(logger === false ? noopHandler : logger || morgan('combined'))
+    .use(aliasPrefix, urlAliasHandler({
+      prefix: aliasPrefix,
       log: log.scope('alias')
     }))
 
@@ -55,7 +58,12 @@ function urlAliasHandler ({ prefix, log }) {
   return (req, res, next) => {
     const uri = req.path.replace(prefix, '')
     log.info(uri)
-    const url = getFullUrl(uri)
+    let url
+    try {
+      url = getFullUrl(uri)
+    } catch (error) {
+      log.error('url alias parse error:', error)
+    }
     if (url) {
       const { hostname, pathname: path } = url
       Object.assign(res.locals, {
@@ -63,8 +71,8 @@ function urlAliasHandler ({ prefix, log }) {
         url: String(url),
         hostname,
         path,
-        originalUrl: Object.keys(req.params).length
-          ? `${path}?${new URLSearchParams(req.params)}`
+        originalUrl: Object.keys(req.query).length
+          ? `${path}?${new URLSearchParams(req.query)}`
           : path
       })
       log.info('url:', uri, String(url))
@@ -74,4 +82,9 @@ function urlAliasHandler ({ prefix, log }) {
       res.status(404).send('Not found')
     }
   }
+}
+
+/** @type {express.RequestHandler} */
+function noopHandler (req, res, next) {
+  return next()
 }

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const morgan = require('morgan')
+const { getFullUrl } = require('./utils')
 
 /**
  * @typedef {import('..').AppOptions} AppOptions
@@ -73,14 +74,4 @@ function urlAliasHandler ({ prefix, log }) {
       res.status(404).send('Not found')
     }
   }
-}
-
-/**
- * @param {string} uri
- * @returns {URL}
- */
-function getFullUrl (uri) {
-  return uri.includes('://')
-    ? new URL(uri)
-    : new URL(`https://${uri}`)
 }

--- a/src/data.js
+++ b/src/data.js
@@ -115,7 +115,7 @@ async function loadRedirectMap (path, options) {
 function applyRedirectOptions (map, options) {
   const {
     'trailing-slash': trailingSlash
-  } = options || {}
+  } = options
   if (trailingSlash) {
     for (const [from, to] of map.entries()) {
       const ext = extname(from)

--- a/src/data.js
+++ b/src/data.js
@@ -1,0 +1,130 @@
+const yaml = require('js-yaml')
+const { extname } = require('node:path')
+const { readFile } = require('node:fs/promises')
+const { join } = require('node:path')
+const { unique, expandEnvVars, mergeMaps } = require('./utils')
+
+module.exports = {
+  getHostnames,
+  getInlineRedirects,
+  loadRedirects,
+  loadRedirectMap,
+  readYAML
+}
+
+/**
+ * @param  {...(string | string[])} urls
+ * @returns {string[]}
+ */
+function getHostnames (...urls) {
+  return urls
+    .flatMap(hostname => {
+      if (hostname.startsWith('.')) {
+        return `*${hostname}`
+      } else if (hostname.startsWith('www.')) {
+        return [hostname, hostname.replace('www.', '')]
+      }
+      return [hostname]
+    })
+    .filter(unique)
+    .map(host => expandEnvVars(host))
+}
+
+/**
+ *
+ * @param {RedirectEntry[]} sources
+ * @param {string} relativeToPath
+ * @returns {Promise<Map<string, string>>}
+ */
+async function loadRedirects (sources, relativeToPath = '.') {
+  const map = new Map()
+  if (!Array.isArray(sources)) {
+    throw new Error(`Expected array of sources, but got ${typeof sources}`)
+  }
+  const fileMaps = await Promise.all(
+    sources
+      .filter(source => source.file)
+      .map(({ file, ...options }) => {
+        const path = relativeToPath ? join(relativeToPath, file) : file
+        return loadRedirectMap(path, options)
+          .then(lines => new Map(lines))
+      })
+  )
+  return mergeMaps(map, ...fileMaps)
+}
+
+/**
+ * Collect all of the redirect entries with a "map" object
+ * into a single Map (from URI => to URL). Keys are merged
+ * in the order they're defined.
+ *
+ * @param {RedirectMapEntry[]} sources
+ * @returns {RedirectMap}
+ */
+function getInlineRedirects (sources) {
+  const map = new Map()
+  if (!sources) return map
+  const maps = sources
+    .filter(source => source.map)
+    .map(({ map, ...options }) => {
+      return applyRedirectOptions(new Map(Object.entries(map)), options)
+    })
+  return mergeMaps(new Map(), ...maps)
+}
+
+/**
+ * Read redirect paths from a file into a single Map. Files are assumed to
+ * consist of zero or more lines with whitespace-separated "columns". Empty
+ * lines and those beginning with "#" are ignored.
+ *
+ * ```
+ * # this is a comment, and will be ignored
+ * # the first and second columns can be separated by any number of spaces or tabs
+ * /foo  https://sf.gov/foo
+ * # any additional "columns" (after the URL) will be ignored
+ * /bar  https://sf.gov # you can put comments here, too
+ * ```
+ *
+ * @param {string} path
+ * @returns {Promise<RedirectMap>}
+ */
+async function loadRedirectMap (path, options) {
+  const data = await readFile(path, 'utf8')
+  const entries = data
+    .split(/[\n\r]+/)
+    .map(line => line.trim())
+    .filter(line => line.length && !line.startsWith('#'))
+    .map(line => line.split(/\s+/))
+  return applyRedirectOptions(new Map(entries), options)
+}
+
+/**
+ *
+ * @param {RedirectMap} map
+ * @param {{ 'trailing-slash': boolean }} options
+ * @returns {RedirectMap}
+ */
+function applyRedirectOptions (map, options) {
+  const {
+    'trailing-slash': trailingSlash
+  } = options || {}
+  if (trailingSlash) {
+    for (const [from, to] of map.entries()) {
+      const ext = extname(from)
+      if (!ext && !from.endsWith('/')) {
+        map.set(`${from}/`, to)
+      }
+    }
+  }
+  return map
+}
+
+/**
+ *
+ * @param {string} path
+ * @returns {Promise<SiteConfigData>}
+ */
+async function readYAML (path) {
+  const data = await readFile(path, 'utf8')
+  return yaml.load(data)
+}

--- a/src/data.js
+++ b/src/data.js
@@ -4,6 +4,14 @@ const { readFile } = require('node:fs/promises')
 const { join } = require('node:path')
 const { unique, expandEnvVars, mergeMaps } = require('./utils')
 
+/**
+ * @typedef {import('..').SiteConfigData} SiteConfigData
+ * @typedef {import('..').RedirectMap} RedirectMap
+ * @typedef {import('..').RedirectEntry} RedirectEntry
+ * @typedef {import('..').RedirectFileEntry} RedirectFileEntry
+ * @typedef {import('..').RedirectMapEntry} RedirectMapEntry
+ */
+
 module.exports = {
   getHostnames,
   getInlineRedirects,

--- a/src/sites.js
+++ b/src/sites.js
@@ -1,10 +1,8 @@
 const express = require('express')
-const { extname } = require('node:path')
-const { readFile } = require('node:fs/promises')
 const { URL } = require('node:url')
 const { dirname, join } = require('node:path')
 const { default: anymatch } = require('anymatch')
-const { unique, expandEnvVars, mergeMaps, readYAML } = require('./utils')
+const { loadRedirects, getHostnames, getInlineRedirects, readYAML } = require('./data')
 const { ARCHIVE_BASE_URL, REDIRECT_PERMANENT } = require('./constants')
 const globby = require('globby')
 const log = require('./log').scope('site')
@@ -278,116 +276,7 @@ class Site {
 }
 
 module.exports = {
-  Site,
-  loadRedirects,
-  loadRedirectMap
-}
-
-/**
- * @param  {...(string | string[])} urls
- * @returns {string[]}
- */
-function getHostnames (...urls) {
-  return urls
-    .flatMap(hostname => {
-      if (hostname.startsWith('.')) {
-        return `*${hostname}`
-      } else if (hostname.startsWith('www.')) {
-        return [hostname, hostname.replace('www.', '')]
-      }
-      return [hostname]
-    })
-    .filter(unique)
-    .map(host => expandEnvVars(host))
-}
-
-/**
- *
- * @param {RedirectEntry[]} sources
- * @param {string} relativeToPath
- * @returns {Promise<Map<string, string>>}
- */
-async function loadRedirects (sources, relativeToPath = '.') {
-  const map = new Map()
-  if (!Array.isArray(sources)) {
-    throw new Error(`Expected array of sources, but got ${typeof sources}`)
-  }
-  const fileMaps = await Promise.all(
-    sources
-      .filter(source => source.file)
-      .map(({ file, ...options }) => {
-        const path = relativeToPath ? join(relativeToPath, file) : file
-        return loadRedirectMap(path, options)
-          .then(lines => new Map(lines))
-      })
-  )
-  return mergeMaps(map, ...fileMaps)
-}
-
-/**
- * Collect all of the redirect entries with a "map" object
- * into a single Map (from URI => to URL). Keys are merged
- * in the order they're defined.
- *
- * @param {RedirectMapEntry[]} sources
- * @returns {RedirectMap}
- */
-function getInlineRedirects (sources) {
-  const map = new Map()
-  if (!sources) return map
-  const maps = sources
-    .filter(source => source.map)
-    .map(({ map, ...options }) => {
-      return applyRedirectOptions(new Map(Object.entries(map)), options)
-    })
-  return mergeMaps(new Map(), ...maps)
-}
-
-/**
- * Read redirect paths from a file into a single Map. Files are assumed to
- * consist of zero or more lines with whitespace-separated "columns". Empty
- * lines and those beginning with "#" are ignored.
- *
- * ```
- * # this is a comment, and will be ignored
- * # the first and second columns can be separated by any number of spaces or tabs
- * /foo  https://sf.gov/foo
- * # any additional "columns" (after the URL) will be ignored
- * /bar  https://sf.gov # you can put comments here, too
- * ```
- *
- * @param {string} path
- * @returns {Promise<RedirectMap>}
- */
-async function loadRedirectMap (path, options) {
-  const data = await readFile(path, 'utf8')
-  const entries = data
-    .split(/[\n\r]+/)
-    .map(line => line.trim())
-    .filter(line => line.length && !line.startsWith('#'))
-    .map(line => line.split(/\s+/))
-  return applyRedirectOptions(new Map(entries), options)
-}
-
-/**
- *
- * @param {RedirectMap} map
- * @param {{ 'trailing-slash': boolean }} options
- * @returns {RedirectMap}
- */
-function applyRedirectOptions (map, options) {
-  const {
-    'trailing-slash': trailingSlash
-  } = options || {}
-  if (trailingSlash) {
-    for (const [from, to] of map.entries()) {
-      const ext = extname(from)
-      if (!ext && !from.endsWith('/')) {
-        map.set(`${from}/`, to)
-      }
-    }
-  }
-  return map
+  Site
 }
 
 /**

--- a/src/sites.js
+++ b/src/sites.js
@@ -10,9 +10,6 @@ const log = require('./log').scope('site')
 /**
  * @typedef {import('..').SiteConfigData} SiteConfigData
  * @typedef {import('..').RedirectMap} RedirectMap
- * @typedef {import('..').RedirectEntry} RedirectEntry
- * @typedef {import('..').RedirectFileEntry} RedirectFileEntry
- * @typedef {import('..').RedirectMapEntry} RedirectMapEntry
  * @typedef {import('..').ISite} ISite
  */
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,7 +9,8 @@ module.exports = {
   expandEnvVars,
   mergeMaps,
   readYAML,
-  unique
+  unique,
+  getFullUrl
 }
 
 /**
@@ -54,4 +55,14 @@ function mergeMaps (map, ...rest) {
     }
   }
   return map
+}
+
+function getFullUrl (url, defaultProtocol = 'https') {
+  if (/^https?:\/\//.test(url)) {
+    return new URL(url)
+  } else if (url.startsWith('//')) {
+    return new URL(`${defaultProtocol}:${url}`)
+  } else {
+    return new URL(`${defaultProtocol}://${url}`)
+  }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,3 @@
-const yaml = require('js-yaml')
-const { readFile } = require('node:fs/promises')
-
 /**
  * @typedef {import('..').SiteConfigData} SiteConfigData
  */
@@ -8,7 +5,6 @@ const { readFile } = require('node:fs/promises')
 module.exports = {
   expandEnvVars,
   mergeMaps,
-  readYAML,
   unique,
   getFullUrl
 }
@@ -29,16 +25,6 @@ function expandEnvVars (str, vars = process.env) {
 
 function unique (value, index, list) {
   return list.indexOf(value) === index
-}
-
-/**
- *
- * @param {string} path
- * @returns {Promise<SiteConfigData>}
- */
-async function readYAML (path) {
-  const data = await readFile(path, 'utf8')
-  return yaml.load(data)
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+const protocolPrefixPattern = /^https?:\/\//
+
 module.exports = {
   expandEnvVars,
   mergeMaps,
@@ -46,7 +48,7 @@ function mergeMaps (map, ...rest) {
  * @returns {URL}
  */
 function getFullUrl (url, defaultProtocol = 'https') {
-  if (/^https?:\/\//.test(url)) {
+  if (protocolPrefixPattern.test(url)) {
     return new URL(url)
   } else if (url.startsWith('//')) {
     return new URL(`${defaultProtocol}:${url}`)

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,3 @@
-/**
- * @typedef {import('..').SiteConfigData} SiteConfigData
- */
-
 module.exports = {
   expandEnvVars,
   mergeMaps,
@@ -43,6 +39,12 @@ function mergeMaps (map, ...rest) {
   return map
 }
 
+/**
+ *
+ * @param {string} url
+ * @param {string?} defaultProtocol
+ * @returns {URL}
+ */
 function getFullUrl (url, defaultProtocol = 'https') {
   if (/^https?:\/\//.test(url)) {
     return new URL(url)


### PR DESCRIPTION
This PR adds a new option to our site config `redirects` objects that adds entries to the redirect map for every key that doesn't already end in a slash with one that does. In other words, given this config:

```yaml
base_url: https://sfgov.org/test
redirects:
  - map:
      /a: https://example.com/a
    trailing-slash: true
  - map:
      /b: https://example.com/b
```

Then both `sfgov.org/test/a` and `sfgov.org/test/a/` will both redirect to `https://example.com/a`; and _only_ `sfgov.org/test/b` will redirect, while `sfgov.org/test/b/` will 404 because the second entry defaults to `trailing-slash: false`. There are [unit tests](https://github.com/SFDigitalServices/archive/blob/feat/redirect-trailing-slashes/__tests__/data.js)!

The rest of this PR is shoring up test coverage and failing builds if we don't have full (100% of lines) coverage. 😱 I've also added the [Coveralls Action](https://github.com/marketplace/actions/coveralls-github-action) so we can see the number in commit statuses.