### PR TITLE
Add HTTP method filter

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -51,6 +51,7 @@ jobs:
       - name: add test subdomains
         if: env.HEROKU_APP_NAME
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         run: |
           PR=$(gh pr view --json number --jq .number)

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -23,15 +23,16 @@ jobs:
         with:
           node-version: 16
 
-      - name: set HEROKU_APP_NAME
-        run: echo HEROKU_APP_NAME="$(scripts/get-app-name.js $TEST_BASE_URL)" >> $GITHUB_ENV
-
       - name: set TEST_BASE_URL from inputs.test_base_url
         if: inputs.test_base_url
         run: echo TEST_BASE_URL="${{ inputs.test_base_url }}" >> $GITHUB_ENV
       - name: set TEST_BASE_URL from deployment payload
         if: github.event.deployment_status.state == 'success' && github.event.deployment.payload.web_url
         run: echo TEST_BASE_URL="${{ github.event.deployment.payload.web_url }}" >> $GITHUB_ENV
+
+      - name: set HEROKU_APP_NAME
+        run: echo HEROKU_APP_NAME="$(scripts/get-app-name.js $TEST_BASE_URL)" >> $GITHUB_ENV
+
       - name: set TEST_SUBDOMAIN from inputs.test_subdomain
         if: inputs.test_subdomain
         run: echo TEST_SUBDOMAIN="${{ inputs.test_subdomain }}" >> $GITHUB_ENV

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           node-version: 16
 
+      - name: set HEROKU_APP_NAME
+        run: echo HEROKU_APP="$(scripts/get-app-name.js $TEST_BASE_URL)" >> $GITHUB_ENV
+
       - name: set TEST_BASE_URL from inputs.test_base_url
         if: inputs.test_base_url
         run: echo TEST_BASE_URL="${{ inputs.test_base_url }}" >> $GITHUB_ENV
@@ -35,16 +38,25 @@ jobs:
       - name: derive TEST_SUBDOMAIN from TEST_BASE_URL
         if: env.TEST_SUBDOMAIN == null
         run: |
-          export HEROKU_APP="$(scripts/get-app-name.js $TEST_BASE_URL)"
-          echo "HEROKU_APP='$HEROKU_APP'"
-          if [ "$HEROKU_APP" != "" ]; then
-            echo TEST_SUBDOMAIN="${HEROKU_APP}." >> $GITHUB_ENV
+          if [ "$HEROKU_APP_NAME" != "" ]; then
+            echo TEST_SUBDOMAIN="${HEROKU_APP_NAME}." >> $GITHUB_ENV
           else
-            echo "HEROKU_APP is empty; not setting TEST_SUBDOMAIN" >> /dev/stderr
+            echo "HEROKU_APP_NAME is empty; not setting TEST_SUBDOMAIN" >> /dev/stderr
           fi
       - name: conditionally set TEST_ENV=production
         if: github.event.deployment.environment == 'sfgov-archive' || github.event.deployment.production_environment
         run: echo TEST_ENV=production >> $GITHUB_ENV
+
+      - name: add test subdomains
+        if: env.HEROKU_APP_NAME
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: |
+          PR=$(gh pr view --json number --jq .number)
+          if [[ "$PR" != "" && "$HEROKU_APP_NAME" != "" ]]; then
+            npm i -g heroku
+            scripts/heroku-add-domains.js "$HEROKU_APP_NAME"
+          fi
 
       - run: npm install
       - run: npm run test:features

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -48,17 +48,13 @@ jobs:
         if: github.event.deployment.environment == 'sfgov-archive' || github.event.deployment.production_environment
         run: echo TEST_ENV=production >> $GITHUB_ENV
 
-      - name: add test subdomains
-        if: env.HEROKU_APP_NAME
+      - name: add test subdomains (for pull requests only)
+        if: contains(env.HEROKU_APP_NAME, '-pr-')
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         run: |
-          PR=$(gh pr view --json number --jq .number)
-          if [[ "$PR" != "" && "$HEROKU_APP_NAME" != "" ]]; then
-            npm i -g heroku
-            scripts/heroku-add-domains.js "$HEROKU_APP_NAME"
-          fi
+          npm i -g heroku
+          scripts/heroku-add-domains.js "$HEROKU_APP_NAME"
 
       - run: npm install
       - run: npm run test:features

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -14,6 +14,9 @@ on:
           is the pull request number.
         required: false
 
+env:
+  PRODUCTION_APP_NAME: sfgov-archive
+
 jobs:
   integration-test:
     runs-on: ubuntu-latest
@@ -45,16 +48,17 @@ jobs:
             echo "HEROKU_APP_NAME is empty; not setting TEST_SUBDOMAIN" >> /dev/stderr
           fi
       - name: conditionally set TEST_ENV=production
-        if: github.event.deployment.environment == 'sfgov-archive' || github.event.deployment.production_environment
+        if: github.event.deployment.environment == env.PRODUCTION_APP_NAME || github.event.deployment.production_environment
         run: echo TEST_ENV=production >> $GITHUB_ENV
 
+      - run: npm install
+
       - name: add test subdomains (for pull requests only)
-        if: contains(env.HEROKU_APP_NAME, '-pr-')
+        if: env.HEROKU_APP_NAME && env.HEROKU_APP_NAME != env.PRODUCTION_APP_NAME
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         run: |
-          npm i -g heroku
+          npm install --location=global heroku
           scripts/heroku-add-domains.js "$HEROKU_APP_NAME"
 
-      - run: npm install
       - run: npm run test:features

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 16
 
       - name: set HEROKU_APP_NAME
-        run: echo HEROKU_APP="$(scripts/get-app-name.js $TEST_BASE_URL)" >> $GITHUB_ENV
+        run: echo HEROKU_APP_NAME="$(scripts/get-app-name.js $TEST_BASE_URL)" >> $GITHUB_ENV
 
       - name: set TEST_BASE_URL from inputs.test_base_url
         if: inputs.test_base_url

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,3 +19,8 @@ jobs:
         run: npm run lint
       - name: unit tests
         run: npm run test:unit
+      - name: Coveralls
+        uses: coverallsapp/github-action@1.1.3
+        with:
+          github-token: ${{ github.token }}
+          flag-name: unit

--- a/__tests__/sites.js
+++ b/__tests__/sites.js
@@ -209,10 +209,12 @@ describe('Site', () => {
           .expect('location', `${ARCHIVE_BASE_URL}/${site.collectionId}/3/https://${site.baseUrl.hostname}/derp`)
       })
 
-      it.skip('404s on un-archive-able URLs', async () => {
+      /*
+      it('404s on un-archive-able URLs', async () => {
         // TODO: flesh this out if/when Site.prototype.getArchiveUrl()
         // ever returns undefined
       })
+      */
     })
 
     describe('sites on a path of sfgov.org', () => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,17 +9,17 @@ export type ArchiveMetadata = {
 
 export type RedirectMap = Map<string, string>
 
-type BaseRedirectEntry = {
+export type RedirectOptions = {
   'trailing-slash': boolean
 }
 
-export type RedirectMapEntry = BaseRedirectEntry & {
+export type RedirectMapEntry = {
   map: Record<string, string>
-}
+} & RedirectOptions
 
-export type RedirectFileEntry = BaseRedirectEntry & {
+export type RedirectFileEntry = {
   file: string
-}
+} & RedirectOptions
 
 export type RedirectEntry = RedirectMapEntry | RedirectFileEntry
 
@@ -40,7 +40,6 @@ export type SiteConfigData = {
 export type AppOptions = {
   sites: ISite[]
   allowedMethods: string[]
-  logger?: express.RequestHandler
 }
 
 export interface ISite {

--- a/scripts/heroku-add-domains.js
+++ b/scripts/heroku-add-domains.js
@@ -21,15 +21,9 @@ if (HEROKU_APP_NAME) {
       if (domains.length) {
         console.log('adding %d domains:', domains.length, domains.join(', '))
         for (const domain of domains) {
-          console.log(`heroku domains:add -a ${HEROKU_APP_NAME} ${domain}`)
-          spawnSync(
-            'heroku',
-            ['domains:add', '-a', HEROKU_APP_NAME, domain],
-            {
-              stdio: 'inherit'
-            }
-          )
+          heroku('domains:add', domain)
         }
+        heroku('domains:wait')
       } else {
         console.warn('no domains found')
       }
@@ -40,4 +34,10 @@ if (HEROKU_APP_NAME) {
     })
 } else {
   console.warn('pass an app name or set HEROKU_APP_NAME')
+}
+
+function heroku (command, args = []) {
+  const allArgs = [command, '-a', HEROKU_APP_NAME, ...args]
+  console.log('[run] heroku', ...allArgs)
+  return spawnSync('heroku', allArgs, { stdio: 'inherit' })
 }

--- a/scripts/heroku-add-domains.js
+++ b/scripts/heroku-add-domains.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/* eslint-disable no-process-exit */
+/* eslint-disable promise/always-return */
+const { Site } = require('../src/sites')
+const { unique } = require('../src/utils')
+const { spawnSync } = require('node:child_process')
+const args = process.argv.slice(2)
+const { HEROKU_APP_NAME = args[0] } = process.env
+
+if (HEROKU_APP_NAME) {
+  const appPrefix = `${HEROKU_APP_NAME}.`
+  const herokuDomain = `${HEROKU_APP_NAME}.herokuapp.com`
+
+  Site.loadAll('config/sites/**/*.yml')
+    .then(sites => {
+      console.info('found %d sites', sites.length)
+      const domains = sites
+        .flatMap(site => site.hostnames)
+        .filter(host => host.includes(appPrefix) && host !== herokuDomain)
+        .filter(unique)
+      if (domains.length) {
+        console.log('adding %d domains:', domains.length, domains.join(', '))
+        for (const domain of domains) {
+          console.log(`heroku domains:add -a ${HEROKU_APP_NAME} ${domain}`)
+          spawnSync(
+            'heroku',
+            ['domains:add', '-a', HEROKU_APP_NAME, domain],
+            {
+              stdio: 'inherit'
+            }
+          )
+        }
+      } else {
+        console.warn('no domains found')
+      }
+    })
+    .catch(error => {
+      console.error('error:', error.message)
+      process.exit(1)
+    })
+} else {
+  console.warn('pass an app name or set HEROKU_APP_NAME')
+}

--- a/scripts/heroku-add-domains.js
+++ b/scripts/heroku-add-domains.js
@@ -36,7 +36,7 @@ if (HEROKU_APP_NAME) {
   console.warn('pass an app name or set HEROKU_APP_NAME')
 }
 
-function heroku (command, args = []) {
+function heroku (command, ...args) {
   const allArgs = [command, '-a', HEROKU_APP_NAME, ...args]
   console.log('[run] heroku', ...allArgs)
   return spawnSync('heroku', allArgs, { stdio: 'inherit' })

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const createApp = require('./src/app')
 const { Site } = require('./src/sites')
 const log = require('./src/log').scope('server')
+const morgan = require('morgan')
 
 const { NODE_ENV } = process.env
 if (NODE_ENV !== 'production') {
@@ -14,6 +15,8 @@ if (!PORT) throw new Error('$PORT is unset')
 Site.loadAll('config/sites/**/*.yml', { cwd: __dirname })
   .then(sites => createApp({ sites }))
   .then(app => {
+    app.use(morgan('combined'))
+
     const server = app.listen(PORT, () => {
       const { address, port } = server.address()
       const host = address === '::' ? 'localhost' : address

--- a/src/data.js
+++ b/src/data.js
@@ -8,6 +8,7 @@ const { unique, expandEnvVars, mergeMaps } = require('./utils')
  * @typedef {import('..').SiteConfigData} SiteConfigData
  * @typedef {import('..').RedirectMap} RedirectMap
  * @typedef {import('..').RedirectEntry} RedirectEntry
+ * @typedef {import('..').RedirectOptions} RedirectOptions
  * @typedef {import('..').RedirectFileEntry} RedirectFileEntry
  * @typedef {import('..').RedirectMapEntry} RedirectMapEntry
  */
@@ -39,7 +40,6 @@ function getHostnames (...urls) {
 }
 
 /**
- *
  * @param {RedirectEntry[]} sources
  * @param {string} relativeToPath
  * @returns {Promise<Map<string, string>>}
@@ -94,6 +94,7 @@ function getInlineRedirects (sources) {
  * ```
  *
  * @param {string} path
+ * @param {RedirectOptions} options
  * @returns {Promise<RedirectMap>}
  */
 async function loadRedirectMap (path, options) {
@@ -107,9 +108,8 @@ async function loadRedirectMap (path, options) {
 }
 
 /**
- *
  * @param {RedirectMap} map
- * @param {{ 'trailing-slash': boolean }} options
+ * @param {RedirectOptions} options
  * @returns {RedirectMap}
  */
 function applyRedirectOptions (map, options) {
@@ -128,7 +128,6 @@ function applyRedirectOptions (map, options) {
 }
 
 /**
- *
  * @param {string} path
  * @returns {Promise<SiteConfigData>}
  */


### PR DESCRIPTION
This adds a short-circuit filter for HTTP methods that will fail fast on requests with methods other than `GET`, `HEAD`, or `OPTIONS` (the "read-only" verbs).

I've also added `scripts/heroku-add-domains.js`, which uses the `HEROKU_APP_NAME` environment variable or the first argument to add subdomains (`$HEROKU_APP_NAME.{domain}`) to review apps (and, I hope, staging). In #13 I experimented with automating this, but I'm doing it in GitHub Actions now, before the acceptance test suite runs, rather than at deploy time. 🥳 