### PR TITLE
Lint scripts, more tests, schema tweaks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,4 +23,3 @@ jobs:
         uses: coverallsapp/github-action@1.1.3
         with:
           github-token: ${{ github.token }}
-          flag-name: unit

--- a/config/schemas/site.json
+++ b/config/schemas/site.json
@@ -48,6 +48,7 @@
             "required": ["map"],
             "properties": {
               "map": {
+                "description": "A mapping from one or more input paths to fully-qualified redirect URLs",
                 "type": "object",
                 "additionalProperties": {
                   "type": "string"
@@ -60,16 +61,17 @@
             }
           },
           {
-            "type": "object",
             "description": "File redirects indicate a file path (relative to the site configuration) containing an httpd-style redirect map",
+            "type": "object",
             "required": ["file"],
             "properties": {
               "file": {
-                "type": "string"
+                "type": "string",
+                "description": "The path of the redirect map file, typically ending in .tsv, relative to this YAML configuration"
               },
               "type": {
-                "oneOf": [
-                  { "const": "tsv" }
+                "enum": [
+                  "tsv"
                 ]
               },
               "trailing-slash": {

--- a/features/innovation.sfgov.feature
+++ b/features/innovation.sfgov.feature
@@ -7,6 +7,17 @@ Feature: innovation.sfgov.org
     When I visit /
     Then I should be redirected to https://sf.gov/departments/mayors-office-innovation
 
-Scenario: Archive URL
+  Scenario: Archive URL
     When I visit /blah
     Then I should be redirected to https://wayback.archive-it.org/19260/3/https://innovation.sfgov.org/blah
+
+  Scenario: Resources links
+    Given request header Host: ${TEST_SUBDOMAIN}archive.sf.gov
+    When I visit /_/innovation.sfgov.org/resources
+    Then I should be redirected to https://sf.gov/departments/mayors-office-innovation#resources
+    When I visit /_/innovation.sfgov.org/resources/
+    Then I should be redirected to https://sf.gov/departments/mayors-office-innovation#resources
+    When I visit /_/www.innovation.sfgov.org/resources
+    Then I should be redirected to https://sf.gov/departments/mayors-office-innovation#resources
+    When I visit /_/www.innovation.sfgov.org/resources/
+    Then I should be redirected to https://sf.gov/departments/mayors-office-innovation#resources

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "develop": "run-p start test:watch",
-    "lint": "eslint .",
+    "lint": "eslint . scripts/*.js",
     "start": "nodemon --config config/nodemon.develop.json server.js",
     "test": "run-s test:unit test:features",
     "test:features": "cucumber-js --config config/cucumber.js",

--- a/scripts/get-canonical-redirects.js
+++ b/scripts/get-canonical-redirects.js
@@ -2,17 +2,15 @@
 /* eslint-disable promise/always-return, promise/catch-or-return */
 const fetch = require('node-fetch')
 const { createWriteStream } = require('node:fs')
-const { dirname } = require('node:path')
-const { loadSite, loadRedirects } = require('../src/sites')
+const { Site } = require('../src/sites')
 
 const args = require('yargs').argv
 
 const [filename, output = '/dev/stdout'] = args._
 
-loadSite(filename)
+Site.load(filename)
   .then(async site => {
-    const redirects = await loadRedirects(site.redirects || [], dirname(site.path))
-    const baseUrl = new URL(site.archive.base_url)
+    const { redirects, baseUrl } = site
     console.warn('checking %d redirects...', redirects.size)
 
     const seen = new Set()


### PR DESCRIPTION
- Add `scripts/*.js` to the `eslint` args in our `lint` script
- Tidy up and add some descriptions to our site configuration schema
- Nix the "unit" option to the coveralls GitHub Action, since there's no coverage for other types of tests
- Add a bunch of redirect smoke tests for permutations of different `innovation.sfgov.org` URLs