### PR TITLE
Add /api/v1/sites endpoints

### DIFF
--- a/__tests__/api.js
+++ b/__tests__/api.js
@@ -1,0 +1,69 @@
+const { createAPIRouter } = require('../src/api')
+const express = require('express')
+const supertest = require('supertest')
+const { Site } = require('../src/sites')
+
+describe('API', () => {
+  describe('createAPIRouter()', () => {
+    const site = new Site({
+      base_url: 'https://example.com',
+      archive: {
+        collection_id: 123
+      },
+      redirects: [
+        {
+          map: {
+            '/': 'https://sf.gov/example'
+          }
+        }
+      ]
+    })
+    const app = express().use(createAPIRouter({ sites: [site] }))
+    it('creates a router that reponds to / with HTML', () => {
+      return supertest(app)
+        .get('/')
+        .expect(200)
+        .expect('content-type', /text\/html/)
+    })
+
+    it('creates a router that reponds to /sites with JSON', () => {
+      return supertest(app)
+        .get('/sites')
+        .expect(200)
+        .expect('content-type', /application\/json/)
+        .expect(res => {
+          expect(res.body).toEqual({
+            status: 'success',
+            data: {
+              sites: [site.toJSON()]
+            }
+          })
+        })
+    })
+
+    it('creates a router that reponds to /sites/:hostname', () => {
+      return supertest(app)
+        .get('/sites/example.com')
+        .expect(200)
+        .expect('content-type', /application\/json/)
+        .expect({
+          status: 'success',
+          data: site.toJSON()
+        })
+    })
+
+    it('creates a router that 404s on /sites/{missing}', () => {
+      return supertest(app)
+        .get('/sites/missing.com')
+        .expect(404)
+        .expect('content-type', /application\/json/)
+        .expect({
+          status: 'error',
+          data: {
+            status: 404,
+            message: 'No site found with hostname "missing.com"'
+          }
+        })
+    })
+  })
+})

--- a/__tests__/api.js
+++ b/__tests__/api.js
@@ -18,7 +18,20 @@ describe('API', () => {
         }
       ]
     })
+
     const app = express().use(createAPIRouter({ sites: [site] }))
+
+    describe('error states', () => {
+      it('throws when multiple sites have the same hostname', () => {
+        expect(() => createAPIRouter({
+          sites: [
+            new Site({ base_url: 'http://example.com' }),
+            new Site({ base_url: 'http://example.com' })
+          ]
+        })).toThrow(/Multiple sites map to the hostname "example.com"/)
+      })
+    })
+
     it('creates a router that reponds to / with HTML', () => {
       return supertest(app)
         .get('/')
@@ -34,9 +47,7 @@ describe('API', () => {
         .expect(res => {
           expect(res.body).toEqual({
             status: 'success',
-            data: {
-              sites: [site.toJSON()]
-            }
+            data: [site.toJSON()]
           })
         })
     })
@@ -58,11 +69,9 @@ describe('API', () => {
         .expect(404)
         .expect('content-type', /application\/json/)
         .expect({
-          status: 'error',
-          data: {
-            status: 404,
-            message: 'No site found with hostname "missing.com"'
-          }
+          status: 'fail',
+          code: 404,
+          message: 'No site found with hostname "missing.com"'
         })
     })
   })

--- a/__tests__/data.js
+++ b/__tests__/data.js
@@ -1,8 +1,26 @@
+/* eslint-disable no-template-curly-in-string */
 const { YAMLException } = require('js-yaml')
-const { loadRedirects, readYAML } = require('../src/data')
+const { getHostnames, loadRedirects, readYAML } = require('../src/data')
 
-describe.skip('getHostnames()', () => {
-  // TODO
+describe('getHostnames()', () => {
+  it('filters out dupes', () => {
+    expect(getHostnames('example.com', 'example.com')).toEqual(['example.com'])
+  })
+
+  it('maps leading "." to "*."', () => {
+    expect(getHostnames('.example.com')).toEqual(['*.example.com'])
+  })
+
+  it('interpolates env vars', () => {
+    // FIXME: mock process.env here
+    process.env.TEST_HOSTNAMES_ENV_VAR = 'wut'
+    expect(getHostnames('${TEST_HOSTNAMES_ENV_VAR}.example.com')).toEqual(['wut.example.com'])
+    delete process.env.TEST_HOSTNAMES_ENV_VAR
+  })
+
+  it('removes entries with empty leading interpolations', () => {
+    expect(getHostnames('${derp}.example.com')).toEqual([])
+  })
 })
 
 describe.skip('getInlineRedirects()', () => {

--- a/config/nodemon.develop.json
+++ b/config/nodemon.develop.json
@@ -11,5 +11,8 @@
     "*.test.js",
     "**/__fixtures__",
     "**/__tests__"
-  ]
+  ],
+  "env": {
+    "NODE_ENV": "development"
+  }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,10 +50,7 @@ export interface SiteJSONData {
   baseUrl: string
   hostnames: string[]
   redirects: Record<string, string>
-  archive: {
-    collectionId?: number
-    active: boolean
-  }
+  collectionId?: number
 }
 
 export interface ISite {

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,6 +42,20 @@ export type AppOptions = {
   allowedMethods: string[]
 }
 
+/**
+ * Sites have a different JSON representation than the config data
+ */
+export interface SiteJSONData {
+  name: string
+  baseUrl: string
+  hostnames: string[]
+  redirects: Record<string, string>
+  archive: {
+    collectionId?: number
+    active: boolean
+  }
+}
+
 export interface ISite {
   name: string
   path?: string
@@ -50,4 +64,5 @@ export interface ISite {
   hostnames?: string[]
   config: SiteConfigData
   createRouter: () => express.RequestHandler
+  toJSON: () => SiteJSONData
 }

--- a/lib/test-setup.js
+++ b/lib/test-setup.js
@@ -1,5 +1,6 @@
 const expect = require('expect')
-const { REDIRECT_PERMANENT } = require('../src/constants')
+const { REDIRECT_PERMANENT, REDIRECT_TEMPORARY } = require('../src/constants')
+const anyRedirectStatus = [REDIRECT_PERMANENT, REDIRECT_TEMPORARY]
 
 expect.extend({
   /**
@@ -38,7 +39,7 @@ expect.extend({
    * @param {string} url
    * @param {number?} expectedStatus
    */
-  toBeFetchRedirect (res, url, expectedStatus = REDIRECT_PERMANENT) {
+  toBeFetchRedirect (res, url, expectedStatus) {
     return matchRedirect({
       status: res.status,
       location: res.headers.get('location')
@@ -65,8 +66,8 @@ expect.extend({
  * @param {number} expectedStatus
  * @returns {{ pass: boolean, message: () => string }}
  */
-function matchRedirect ({ status, location }, expectedLocation, expectedStatus = REDIRECT_PERMANENT) {
-  const matchesStatus = status === expectedStatus
+function matchRedirect ({ status, location }, expectedLocation, expectedStatus) {
+  const matchesStatus = isRedirectStatus(status, expectedStatus)
   const matchesLocation = location === expectedLocation
   return {
     pass: matchesStatus && matchesLocation,
@@ -76,4 +77,10 @@ function matchRedirect ({ status, location }, expectedLocation, expectedStatus =
         : `Expected ${expectedStatus}, but got ${status}`
     }
   }
+}
+
+function isRedirectStatus (status, expectedStatus) {
+  return expectedStatus
+    ? status === expectedStatus
+    : anyRedirectStatus.includes(status)
 }

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+/* eslint-disable promise/catch-or-return */
 const createApp = require('./src/app')
 const { Site } = require('./src/sites')
 const log = require('./src/log').scope('server')
@@ -23,9 +24,4 @@ Site.loadAll('config/sites/**/*.yml', { cwd: __dirname })
       log.info('listening on http://%s:%d', host, port)
     })
     return server
-  })
-  .catch(error => {
-    console.error(error)
-    // eslint-disable-next-line no-process-exit
-    process.exit(1)
   })

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,63 @@
+const { Router } = require('express')
+const { Site } = require('./sites')
+
+/**
+ * @typedef {import('express').RequestHandler} RequestHandler
+ */
+
+module.exports = {
+  /**
+   * @param {import('..').AppOptions?} options
+   */
+  createApiRouter (config) {
+    const { sites = [] } = config || {}
+
+    const router = new Router({
+      caseSensitive: true,
+      mergeParams: true
+    })
+
+    /** @type {import('..').SiteJSONData[]} */
+    const staticSitesData = sites
+      .filter(site => site instanceof Site)
+      .map(site => site.toJSON())
+
+    /** @type {Map<string, import('..').SiteJSONData>} */
+    const sitesByHostname = new Map()
+    for (const site of staticSitesData) {
+      for (const host of site.hostnames) {
+        sitesByHostname.set(host, site)
+      }
+    }
+
+    router.get('/sites', /** @type {RequestHandler} */ (req, res) => {
+      res.json({
+        status: 'success',
+        data: {
+          sites: staticSitesData
+        }
+      })
+    })
+
+    router.get('/site/:hostname', /** @type {RequestHandler} */ (req, res) => {
+      const { hostname } = req.params
+      const site = sitesByHostname.get(hostname)
+      if (site) {
+        return res.json({
+          status: 'success',
+          data: site.toJSON()
+        })
+      } else {
+        return res.status(404).json({
+          status: 'error',
+          data: {
+            status: 404,
+            message: `No site found with hostname "${hostname}"`
+          }
+        })
+      }
+    })
+
+    return router
+  }
+}

--- a/src/api.js
+++ b/src/api.js
@@ -1,64 +1,53 @@
-const { Router } = require('express')
+const express = require('express')
 const { Site } = require('./sites')
 // const log = require('./log').scope('api')
 
 /**
  * @typedef {import('express').RequestHandler} RequestHandler
+ * @typedef {import('..').SiteJSONData} SiteJSONData
  */
+
+const GITHUB_BASE_URL = 'https://github.com/SFDigitalServices/archive'
+const SFDS_BASE_URL = 'https://unpkg.com/sfgov-design-system@2.4.0'
+const html = String.raw
 
 module.exports = {
   /**
-   * @param {import('..').AppOptions?} options
-   * @returns {Router}
+   * @param {{ sites: Site[] }} options
+   * @returns {express.Application}
    */
-  createAPIRouter (config) {
-    const { sites = [] } = config || {}
+  createAPIRouter (options) {
+    const { sites } = options
 
-    const router = new Router({
-      caseSensitive: true,
-      mergeParams: true
-    })
+    const api = express.Router()
 
-    /** @type {import('..').SiteJSONData[]} */
+    /** @type {SiteJSONData[]} */
     const staticSitesData = sites
       .filter(site => site instanceof Site)
       .map(site => site.toJSON())
 
-    /** @type {Map<string, import('..').SiteJSONData>} */
+    /** @type {Map<string, SiteJSONData>} */
     const sitesByHostname = new Map()
     for (const site of staticSitesData) {
       for (const host of site.hostnames) {
+        if (sitesByHostname.has(host)) {
+          const existing = sitesByHostname.get(host)
+          throw new Error(`Multiple sites map to the hostname "${host}": ${existing.name} (${existing.baseUrl}) and ${site.name} (${site.baseUrl})`)
+        }
         sitesByHostname.set(host, site)
       }
     }
 
-    router.get('/', /** @type {RequestHandler} */ (req, res) => {
-      const path = req.baseUrl
-      res.send(`
-        <h1>archive API v1</h1>
-        <h2>Sites</h2>
-        <ul>
-          <li><a href="${path}/sites"><code>${path}/sites</code></a> returns all of the known sites as an array</li>
-          <li><code>${path}/sites/:domain</code> returns the site with a hostname matching <code>:domain</code>, e.g.
-            <ul>
-              <li><a href="${path}/sites/innovation.sfgov.org">innovation.sfgov.org</a></li>
-              <li><a href="${path}/sites/sftreasureisland.org">sftreasureisland.org</a></li>
-            </ul>
-          </li>
-        </ul>
-      `)
-    })
+    /** @type {string[]} */
+    const availableHostnames = [...sitesByHostname.keys()]
+      .filter(host => host !== 'localhost' && !host.startsWith('.'))
+      .sort()
 
-    router.get('/sites', /** @type {RequestHandler} */ (req, res) => {
-      res.json({
-        status: 'success',
-        data: {
-          sites: staticSitesData
-        }
-      })
-    })
+    api.get('/', documentationHandler)
 
-    router.get('/sites/:hostname', /** @type {RequestHandler} */ (req, res) => {
+    api.get('/hostnames', staticDataHandler(availableHostnames))
+
+    api.get('/sites/:hostname', /** @type {RequestHandler} */ (req, res) => {
       const { hostname } = req.params
       const site = sitesByHostname.get(hostname)
       if (site) {
@@ -68,15 +57,64 @@ module.exports = {
         })
       } else {
         return res.status(404).json({
-          status: 'error',
-          data: {
-            status: 404,
-            message: `No site found with hostname "${hostname}"`
-          }
+          status: 'fail',
+          code: 404,
+          message: `No site found with hostname "${hostname}"`
         })
       }
     })
 
-    return router
+    api.get('/sites', staticDataHandler(staticSitesData))
+
+    return api
+
+    /**
+     * @param {any} data
+     * @returns {RequestHandler}
+     */
+    function staticDataHandler (data, additionalProps = {}) {
+      return (req, res) => res.json({
+        status: 'success',
+        data,
+        ...additionalProps
+      })
+    }
   }
+}
+
+/** @type {RequestHandler} */
+function documentationHandler (req, res) {
+  const path = req.baseUrl
+  return res.send(html`
+    <!doctype html>
+    <html lang="en">
+    <head>
+      <link rel="stylesheet" href="${SFDS_BASE_URL}/dist/css/sfds.css">
+      <link rel="stylesheet" href="${SFDS_BASE_URL}/dist/css/fonts.css">
+    </head>
+    <body class="responsive-container py-80">
+      <h1 class="display-lg m-0">archive API v1</h1>
+
+      <h2 class="title-md my-16" id="sites">Sites</h2>
+      <p>
+        Each "site" corresponds to a YAML configuration in
+        <a href="${GITHUB_BASE_URL}/tree/main/config/sites#readme">the <code>config/sites</code> directory</a>,
+        and describes an archived site for which this server will manage redirects. Each site has one or more
+        <a href="#hostnames">hostnames</a> to which this server will respond.
+      </p>
+      <ul>
+        <li><a href="${path}/sites"><code>${path}/sites</code></a> returns all of the known sites as an array</li>
+        <li><code>${path}/sites/:hostname</code> returns the site with the given <a href="#hostnames">hostname</a></li></li>
+      </ul>
+
+      <h2 class="title-md my-16" id="hostnames">Hostnames</h2>
+      <p>
+        Assuming DNS is properly configured (or with the appropriate <code>Host</code> header over insecure HTTP),
+        this server will respond to any of the hostnames listed in its <a href="#sites">site</a> configurations.
+      </p>
+      <ul>
+        <li><a href="${path}/hostnames"><code>${path}/hostnames</code></a> lists all of the available hostnames</li>
+      </ul>
+    </body>
+  `)
 }

--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,6 @@
 const { Router } = require('express')
 const { Site } = require('./sites')
-const log = require('./log').scope('api')
+// const log = require('./log').scope('api')
 
 /**
  * @typedef {import('express').RequestHandler} RequestHandler

--- a/src/api.js
+++ b/src/api.js
@@ -1,5 +1,6 @@
 const { Router } = require('express')
 const { Site } = require('./sites')
+const log = require('./log').scope('api')
 
 /**
  * @typedef {import('express').RequestHandler} RequestHandler
@@ -8,8 +9,9 @@ const { Site } = require('./sites')
 module.exports = {
   /**
    * @param {import('..').AppOptions?} options
+   * @returns {Router}
    */
-  createApiRouter (config) {
+  createAPIRouter (config) {
     const { sites = [] } = config || {}
 
     const router = new Router({
@@ -30,6 +32,23 @@ module.exports = {
       }
     }
 
+    router.get('/', /** @type {RequestHandler} */ (req, res) => {
+      const path = req.baseUrl
+      res.send(`
+        <h1>archive API v1</h1>
+        <h2>Sites</h2>
+        <ul>
+          <li><a href="${path}/sites"><code>${path}/sites</code></a> returns all of the known sites as an array</li>
+          <li><code>${path}/sites/:domain</code> returns the site with a hostname matching <code>:domain</code>, e.g.
+            <ul>
+              <li><a href="${path}/sites/innovation.sfgov.org">innovation.sfgov.org</a></li>
+              <li><a href="${path}/sites/sftreasureisland.org">sftreasureisland.org</a></li>
+            </ul>
+          </li>
+        </ul>
+      `)
+    })
+
     router.get('/sites', /** @type {RequestHandler} */ (req, res) => {
       res.json({
         status: 'success',
@@ -39,13 +58,13 @@ module.exports = {
       })
     })
 
-    router.get('/site/:hostname', /** @type {RequestHandler} */ (req, res) => {
+    router.get('/sites/:hostname', /** @type {RequestHandler} */ (req, res) => {
       const { hostname } = req.params
       const site = sitesByHostname.get(hostname)
       if (site) {
         return res.json({
           status: 'success',
-          data: site.toJSON()
+          data: site
         })
       } else {
         return res.status(404).json({

--- a/src/app.js
+++ b/src/app.js
@@ -45,7 +45,7 @@ module.exports = async function createApp (options) {
     }
   }
 
-  app.use('/api/v1', createAPIRouter(options))
+  // app.use('/api/v1', createAPIRouter(options))
 
   /*
    * app.use() here mounts the site router at a URI pattern matching

--- a/src/app.js
+++ b/src/app.js
@@ -45,7 +45,7 @@ module.exports = async function createApp (options) {
     }
   }
 
-  // app.use('/api/v1', createAPIRouter(options))
+  app.use('/api/v1', createAPIRouter({ sites }))
 
   /*
    * app.use() here mounts the site router at a URI pattern matching

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const { default: httpMethodFilter } = require('http-method-filter')
+const { createApiRouter } = require('./api')
 const { removePrefix } = require('./utils')
 
 /**
@@ -53,6 +54,8 @@ module.exports = async function createApp (options) {
    * the request path, and the site router knows no difference.
    */
   app.use('/_/:hostname([^/]+)', hostnamePathMiddleware('/_'), siteRouter)
+
+  app.use('/api/v1', createApiRouter(options))
 
   app.use(siteRouter)
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,6 @@
 const express = require('express')
 const { default: httpMethodFilter } = require('http-method-filter')
-const { createApiRouter } = require('./api')
+const { createAPIRouter } = require('./api')
 const { removePrefix } = require('./utils')
 
 /**
@@ -45,6 +45,8 @@ module.exports = async function createApp (options) {
     }
   }
 
+  app.use('/api/v1', createAPIRouter(options))
+
   /*
    * app.use() here mounts the site router at a URI pattern matching
    * `/_/:hostname` (where `:hostname` matches anything except `/`), preceded by
@@ -54,8 +56,6 @@ module.exports = async function createApp (options) {
    * the request path, and the site router knows no difference.
    */
   app.use('/_/:hostname([^/]+)', hostnamePathMiddleware('/_'), siteRouter)
-
-  app.use('/api/v1', createApiRouter(options))
 
   app.use(siteRouter)
 

--- a/src/data.js
+++ b/src/data.js
@@ -37,6 +37,7 @@ function getHostnames (...urls) {
     })
     .filter(unique)
     .map(host => expandEnvVars(host))
+    .filter(host => !host.startsWith('.'))
 }
 
 /**

--- a/src/sites.js
+++ b/src/sites.js
@@ -277,14 +277,11 @@ class Site {
    */
   toJSON () {
     return {
-      name: this.config.name,
+      name: this.config.name || '',
       baseUrl: this.baseUrl.toString(),
       hostnames: this.hostnames,
       redirects: Object.fromEntries(this.redirects.entries()),
-      archive: {
-        active: this.config.archive?.active === true,
-        collectionId: this.collectionId
-      }
+      collectionId: this.collectionId
     }
   }
 }

--- a/src/sites.js
+++ b/src/sites.js
@@ -271,6 +271,22 @@ class Site {
       staticConfig.options
     ))
   }
+
+  /**
+   * @returns {import('..').SiteJSONData}
+   */
+  toJSON () {
+    return {
+      name: this.config.name,
+      baseUrl: this.baseUrl.toString(),
+      hostnames: this.hostnames,
+      redirects: Object.fromEntries(this.redirects.entries()),
+      archive: {
+        active: this.config.archive?.active === true,
+        collectionId: this.collectionId
+      }
+    }
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
- `/api/v1/sites` returns JSON representations of all of the sites (as an array)
- `/api/v1/sites/:hostname` returns JSON for the site with the provided hostname in its `hostnames` array

### TODO
- [ ] Figure out why the heck this isn't running on Heroku??
- [ ] Add tests
- [ ] Add links to the homepage
- [ ] Add build metadata endpoint?