### PR TITLE
Add sf-hrc.org

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,11 @@
     "editor.formatOnSave": true,
     "editor.formatOnSaveMode": "file"
   },
+  "[tsv]": {
+    "editor.tabSize": 4,
+    "editor.useTabStops": true,
+    "editor.insertSpaces": false
+  },
   "yaml.schemas": {
     "config/schemas/site.json": "config/sites/**/*.yml"
   }

--- a/config/sites/hrc/hrc.tsv
+++ b/config/sites/hrc/hrc.tsv
@@ -1,0 +1,1 @@
+/	https://sf.gov/departments/human-rights-commission

--- a/config/sites/hrc/hrc.yml
+++ b/config/sites/hrc/hrc.yml
@@ -1,0 +1,12 @@
+name: Human Rights Commission
+base_url: https://sf-hrc.org
+
+archive:
+  collection_id: 19238
+
+hostnames:
+  - www.sf-hrc.org
+  - '${HEROKU_APP_NAME}.sf-hrc.org'
+
+redirects:
+  - file: hrc.tsv

--- a/features/sf-hrc.feature
+++ b/features/sf-hrc.feature
@@ -1,0 +1,18 @@
+@site
+Feature: sf-hrc.org
+  Background: default hostname
+    Given request header Host: ${TEST_SUBDOMAIN}sf-hrc.org
+
+  Scenario: /
+    When I visit /
+    Then I should be redirected to https://sf.gov/departments/human-rights-commission
+
+  Scenario: Archive URL
+    When I visit /blah
+    Then I should be redirected to https://wayback.archive-it.org/19238/3/https://sf-hrc.org/blah
+
+  @prod-only
+  Scenario: sf-hrc.org/
+    Given request header Host: ${TEST_SUBDOMAIN}sf-hrc.org
+    When I visit /
+    Then I should be redirected to https://sf.gov/departments/human-rights-commission


### PR DESCRIPTION
This adds the Human Rights Commission site at `sf-hrc.org` to the archive server so that we can shut down the Drupal 7 site. I've created Service Now ticket SER0439491 to request pointing `sf-hrc.org` at Heroku's DNS target.