### PR TITLE
Spike: crawl script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,8 @@
 # Logs
-logs
+logs/
 *.log
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-lerna-debug.log*
-
-# Diagnostic reports (https://nodejs.org/api/report.html)
-report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+*-debug.log*
+*-error.log*
 
 # Runtime data
 pids
@@ -17,14 +12,9 @@ pids
 
 # Coverage directories
 coverage
-lib-cov
-.nyc_output
 
 # Dependency directories
 node_modules/
-
-# TypeScript v1 declaration files
-typings/
 
 # Optional npm cache directory
 .npm
@@ -41,9 +31,3 @@ typings/
 # dotenv environment variables file
 .env
 .env.test
-
-# parcel-bundler cache (https://parceljs.org/)
-.cache
-
-# TypeScript output
-dist

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,10 @@
     "editor.formatOnSave": true,
     "editor.formatOnSaveMode": "file"
   },
+  "files.associations": {
+    "*.wgetrc": "ini",
+    ".wgetrc": "ini"
+  },
   "yaml.schemas": {
     "config/schemas/site.json": "config/sites/**/*.yml"
   }

--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -3,3 +3,4 @@ reentrysf
 sfgov
 sf.gov
 sftreasureisland
+adr

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Implicit redirects to archived snapshots assume that all of the URLs for a legac
 
 This is the process by which a single [document](#document) (typically a web page) is crawled and a "snapshot" is saved for public consumption with a web browser. The specific archival mechanism is under review and will be detailed in a forthcoming [ADR](#adrs).
 
-### Legacy site
+### Legacy sites
 
 A "legacy site" is any City-owned site that is no longer relevant and/or superseded by more up-to-date content on [sf.gov]. Most of these are department and public body sites served under subdomains of `sfgov.org`, but some are served on other domains, such as the Board of Supervisors' `sfbos.org` or the Treasure Island Development Authority's `sftreasureisland.org`.
 
@@ -41,12 +41,11 @@ In this repo, the term "document" refers to either a web page in HTML or a well-
 
 ## ADRs
 
-We use [**A**rchitectural **D**ecision **R**ecords][adr] to propose, evaluate, and make decisions about technical architecture. Our ADRs are written as [Markdown] in the [docs/adr directory](./docs/adr).
+We use [Architectural Decision Records][adr] to propose, evaluate, and make decisions about technical architecture. Our ADRs are written as [Markdown] in the [docs/adr directory](./docs/adr).
 
 [sf.gov]: https://sf.gov
 [adr]: https://github.com/joelparkerhenderson/architecture-decision-record#what-is-an-architecture-decision-record
 [markdown]: https://en.wikipedia.org/wiki/Markdown
-[sfgov.org]: https://sfgov.org
 [404]: https://en.wikipedia.org/wiki/HTTP_404
 [301]: https://en.wikipedia.org/wiki/HTTP_301
 [location header]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location

--- a/lib/crawl.js
+++ b/lib/crawl.js
@@ -1,0 +1,135 @@
+/* eslint-disable promise/always-return */
+const { spawn } = require('node:child_process')
+const { mkdir, readFile, writeFile } = require('node:fs/promises')
+const { URL } = require('node:url')
+const { join } = require('node:path')
+const pretty = require('pretty-time')
+
+const outdir = 'public/archive'
+
+const catchAllFilesPath = [
+  '/sites/',
+  '/sfc/sites/'
+]
+
+const wgetArgs = [
+  '--adjust-extension',
+  '--compression', 'gzip',
+  '--convert-links',
+  '--directory-prefix', outdir,
+  '--page-requisites',
+  '--recursive',
+  '--timestamping',
+  '--user-agent', 'Archive-It',
+  '--include-directories', catchAllFilesPath.join(',')
+]
+
+module.exports = {
+  crawl,
+  catchAllFilesPath,
+  getRejected,
+  getSavedFiles
+}
+
+async function crawl (urlish, extraArgs = []) {
+  const url = new URL(urlish, 'https://sfgov.org')
+  const { hostname, pathname } = url
+  const logDir = join('logs', hostname, pathname)
+
+  await mkdir(logDir, { recursive: true })
+  await mkdir(outdir, { recursive: true })
+
+  const logPath = join(logDir, 'wget.log')
+  const rejectedLogPath = join(logDir, 'wget.rejected.tsv')
+
+  const args = [
+    ...wgetArgs,
+    '--output-file', logPath,
+    '--rejected-log', rejectedLogPath,
+    '--include-directories', pathname,
+    ...extraArgs,
+    url
+  ].map(String)
+
+  console.log('🦀 crawling: %s (log file: %s)', url, logPath)
+  // console.log('→ `wget %s`', args.map(shellQuote).join(' '))
+
+  return new Promise((resolve, reject) => {
+    const start = process.hrtime()
+    const proc = spawn('wget', args, {
+      detached: true
+    })
+
+    proc.on('error', error => {
+      reject(new Error(`Crawl failed: \`wget ${args.map(shellQuote)}\` error: ${error.message}`))
+    })
+
+    proc.on('close', (code, signal) => {
+      const elapsed = process.hrtime(start)
+      console.log('✅ done crawling: %s (finished in %s)', url, seconds(elapsed))
+      // console.log('🔎 gathering crawl info...')
+      Promise.all([
+        getSavedFiles(logPath),
+        getRejected(rejectedLogPath)
+      ])
+        .then(async ([saved, rejected]) => {
+          const actualRejected = rejected
+            // .filter(item => item.REASON !== 'BLACKLIST')
+            .map(entry => decodeURIComponent(entry.U_URL))
+            .filter(Boolean)
+            .filter(unique)
+            .sort()
+          const rejectedListPath = join(logDir, 'rejected.txt')
+          await writeFile(rejectedListPath, actualRejected.join('\n'))
+          resolve({
+            url: url.toString(),
+            log: logPath,
+            wgetArgs: args,
+            saved,
+            rejected,
+            rejectedListPath
+          })
+        })
+        .catch(reject)
+    })
+  })
+}
+
+function shellQuote (str) {
+  return str.match(/[\s"&*?]/)
+    ? `'${str}'`
+    : str
+}
+
+async function getRejected (logPath) {
+  const data = await readFile(logPath, 'utf8')
+  const lines = data.split('\n')
+    .filter(Boolean)
+    .map(line => line.split('\t'))
+  const headers = lines.shift()
+  return lines.map(row => Object.fromEntries(row.map((val, i) => [headers[i], val])))
+}
+
+async function getSavedFiles (logPath) {
+  const data = await readFile(logPath, 'utf8')
+  const urls = []
+  const paths = []
+  data.replace(/--\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}--\s+(\S+)\n/, (_, url) => {
+    urls.push(url)
+  })
+  data.replace(/Saving to: ‘([^’]+)’/g, (_, path) => {
+    paths.push(path)
+  })
+  return {
+    urls,
+    paths
+  }
+}
+
+function unique (item, index, list) {
+  return list.indexOf(item) === index
+}
+
+function seconds (ms) {
+  return pretty(ms, 's')
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "morgan": "^1.10.0",
         "nodemon": "^2.0.18",
         "npm-run-all": "^4.1.5",
+        "pretty-time": "^1.1.0",
         "signales": "^2.0.5"
       },
       "devDependencies": {
@@ -10214,6 +10215,14 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/pretty-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-time/-/pretty-time-1.1.0.tgz",
+      "integrity": "sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -19778,6 +19787,11 @@
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
       }
+    },
+    "pretty-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-time/-/pretty-time-1.1.0.tgz",
+      "integrity": "sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA=="
     },
     "progress": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "morgan": "^1.10.0",
     "nodemon": "^2.0.18",
     "npm-run-all": "^4.1.5",
+    "pretty-time": "^1.1.0",
     "signales": "^2.0.5"
   },
   "devDependencies": {

--- a/public/.gitignore
+++ b/public/.gitignore
@@ -1,2 +1,2 @@
-sf-hrc.org/
-sfdbi.org/
+archive/
+.*

--- a/public/.gitignore
+++ b/public/.gitignore
@@ -1,0 +1,2 @@
+sf-hrc.org/
+sfdbi.org/

--- a/scripts/crawl.js
+++ b/scripts/crawl.js
@@ -1,0 +1,29 @@
+/* eslint-disable promise/always-return */
+const { crawl } = require('../lib/crawl')
+
+const crawls = [
+  crawl('https://sfgov.org/bac/', [
+    '--include-directories', '/sfc/bac/'
+  ]),
+  crawl('https://sfgov.org/arts/', [
+    // '--reject=.pdf'
+  ]),
+  crawl('https://sfgov.org/dosw/', [
+  ])
+]
+
+Promise.all(crawls)
+  .then(results => {
+    // console.log('all done!', results)
+    for (const { url, saved, rejected, rejectedListPath } of results) {
+      console.log('crawled: %s', url)
+      console.log('  + %d files saved', saved.paths.length)
+      console.log('  + %d urls crawled', saved.urls.length)
+      console.log('  - %d urls rejected (list: %s)', rejected.length, rejectedListPath)
+    }
+  })
+  .catch(error => {
+    console.error('Error:', error)
+    // eslint-disable-next-line no-process-exit
+    process.exit(1)
+  })


### PR DESCRIPTION
For PUBX-295, this adds a Node.js wrapper around [wget] and scaffolds a script to run a small number of crawls in parallel. This all happens on the same thread, but could be easily distributed across threads (i.e. with [workers](https://nodejs.org/docs/latest-v18.x/api/worker_threads.html#new-workerfilename-options)) and/or machines.

The core crawling logic lives in [lib/crawl.js](https://github.com/SFDigitalServices/archive/blob/breaking/crawler/lib/crawl.js), and is invoked once per site in [scripts/crawl.js](https://github.com/SFDigitalServices/archive/blob/breaking/crawler/scripts/crawl.js). The script outputs summary of the work performed to stdout, writes the crawled files to `public/archive/{hostname}/{pathname}`, and logs more detailed output for each crawl to `logs/{hostname}/{pathname}`:

```
node scripts/crawl.js
🦀 crawling: https://sfgov.org/arts/ (log file: logs/sfgov.org/arts/wget.log)
🦀 crawling: https://sfgov.org/bac/ (log file: logs/sfgov.org/bac/wget.log)
🦀 crawling: https://sfgov.org/dosw/ (log file: logs/sfgov.org/dosw/wget.log)
✅ done crawling: https://sfgov.org/bac/ (finished in 25s)
✅ done crawling: https://sfgov.org/arts/ (finished in 8m 34s)
✅ done crawling: https://sfgov.org/dosw/ (finished in 8m 58s)
crawled: https://sfgov.org/bac/
  + 156 files saved
  + 1 urls crawled
  - 5215 urls rejected (list: logs/sfgov.org/bac/rejected.txt)
crawled: https://sfgov.org/arts/
  + 3926 files saved
  + 1 urls crawled
  - 114937 urls rejected (list: logs/sfgov.org/arts/rejected.txt)
crawled: https://sfgov.org/dosw/
  + 2342 files saved
  + 1 urls crawled
  - 104562 urls rejected (list: logs/sfgov.org/dosw/rejected.txt)
```

File sizes for the three sites crawled:

```
% du -d0 -h public/archive/sfgov.org/*
2.7G    public/archive/sfgov.org/arts
1.5M    public/archive/sfgov.org/bac
611M    public/archive/sfgov.org/dosw
4.0K    public/archive/sfgov.org/robots.txt
 46M    public/archive/sfgov.org/sfc
108K    public/archive/sfgov.org/sites
```

### wget arguments
All crawls run the [`wget` CLI][wget] with the following args:

* `--recursive` crawls recursively
* `--compression=gzip` for faster downloading
* `--page-requisites` ensures that linked images, CSS, and JS are also downloaded
* `--convert-links` "convert[s] the links in the document to make them suitable for local viewing. This affects not only the visible hyperlinks, but any part of the document that links to external content, such as embedded images, links to style sheets, hyperlinks to non-HTML content, etc."
* `--user-agent="Archive-It"` disables redirects to `sf.gov` on our D7 sites (via a module that Chapter Three built for us)
* `--include-directories=/sites/,/sfc/sites` appears to be necessary in order to safelist "page requisites" (assets) that live outside of the initial crawl URL, which is true for almost every `sfgov.org` D7 site.

    This option can be repeated, so individual site crawling jobs can pass their own `--include-directories` options as needed. You can see in `scripts/crawl.js` that the crawl of `sfgov.org/bac/` adds `--include-directories=/sfc/bac/` since that's the canonical URL.

Arguments that are up for discussion include:

* `--adjust-exension` appends the filename of HTML responses with `.html`. This seems to make mirroring on S3 the most straightforward (because we don't have to remember to include `Content-Type: text/html` in the headers), but likely makes preserving old URLs a bit trickier because e.g. `sfgov.org/some-site/page/` writes to `some-site/page.html`, which would not resolve `/some-site/page/` without additional routing logic.

* `--timestamping` enables [timestamping](https://www.gnu.org/software/wget/manual/wget.html#Time_002dStamping-Usage), which doesn't appear to work because most sites don't serve `Last-Modified` headers ☹️ 

### Rejected URLs
wget helpfully emits a TSV file listing rejected URLs, but it's a bit wonky: they include (sometimes multiple) entries for URLs that _are_ downloaded, and confusingly set the "reason" column for these entries to either `BLACKLIST`. Additional work is necessary to read this TSV file and remove entries for files that were downloaded so that we can accurately list the URLs that weren't crawled.

I also attempted to parse the wget output for URLs and paths crawled, but this isn't well tested or accurate yet.

[wget]: https://www.gnu.org/software/wget/manual/wget.html#Invoking